### PR TITLE
Bug fixes and speedier gameplay

### DIFF
--- a/asm/macros/battle_script.inc
+++ b/asm/macros/battle_script.inc
@@ -79,7 +79,7 @@
 
 	.macro waitmessage param0:req
 	.byte 0x12
-	.2byte \param0
+	.2byte 0x01
 	.endm
 
 	.macro printfromtable ptr:req
@@ -325,7 +325,7 @@
 
 	.macro pause param0:req
 	.byte 0x39
-	.2byte \param0
+	.2byte 0x01
 	.endm
 
 	.macro waitstate

--- a/data/scripts/pkmn_center_nurse.inc
+++ b/data/scripts/pkmn_center_nurse.inc
@@ -1,18 +1,10 @@
 EventScript_PkmnCenterNurse::
 	goto_if_questlog EventScript_ReleaseEnd
-	message Text_WelcomeWantToHealPkmn
-	waitmessage
-	multichoice 19, 8, MULTICHOICE_YES_NO, FALSE | (TRUE << 1)
-	switch VAR_RESULT
-	case 0, EventScript_PkmnCenterNurse_HealPkmn
-	case 1 EventScript_PkmnCenterNurse_Goodbye
-	case SCR_MENU_CANCEL, EventScript_PkmnCenterNurse_Goodbye
+	call EventScript_PkmnCenterNurse_HealPkmn
 	end
 
 EventScript_PkmnCenterNurse_HealPkmn::
 	incrementgamestat GAME_STAT_USED_POKECENTER
-	message Text_TakeYourPkmnForFewSeconds
-	waitmessage
 	call EventScript_PkmnCenterNurse_TakeAndHealPkmn
 	special SetUsedPkmnCenterQuestLogEvent
 	goto EventScript_PkmnCenterNurse_CheckTrainerTowerAndUnionRoom
@@ -38,11 +30,8 @@ EventScript_PkmnCenterNurse_CheckTrainerTowerAndUnionRoom::
 	end
 
 EventScript_PkmnCenterNurse_ReturnPkmn::
-	message Text_RestoredPkmnToFullHealth
-	waitmessage
 	applymovement VAR_LAST_TALKED, Movement_Bow
 	waitmovement 0
-	msgbox Text_WeHopeToSeeYouAgain
 	return
 
 EventScript_PkmnCenterNurse_PlayerWaitingInUnionRoom::

--- a/data/text/new_game_intro.inc
+++ b/data/text/new_game_intro.inc
@@ -159,32 +159,14 @@ gOakSpeech_Text_AskPlayerGender::
     .string "Or are you a girl?$"
 
 gPikachuIntro_Text_Page1::
-    .string "In the world which you are about to\n"
-    .string "enter, you will embark on a grand\n"
-    .string "adventure with you as the hero.\n"
+    .string "Welcome to the POKéMON Challenge!\n"
     .string "\n"
-    .string "Speak to people and check things\n"
-    .string "wherever you go, be it towns, roads,\n"
-    .string "or caves. Gather information and\n"
-    .string "hints from every source.$"
-
-gPikachuIntro_Text_Page2::
-    .string "New paths will open to you by helping\n"
-    .string "people in need, overcoming challenges,\n"
-    .string "and solving mysteries.\n"
+    .string "POKéMON, items, and more will be\n"
+    .string "randomized based on the name you\n"
+    .string "give your rival in the next scene.\n"
     .string "\n"
-    .string "At times, you will be challenged by\n"
-    .string "others and attacked by wild creatures.\n"
-    .string "Be brave and keep pushing on.$"
-
-gPikachuIntro_Text_Page3::
-    .string "Through your adventure, we hope\n"
-    .string "that you will interact with all sorts\n"
-    .string "of people and achieve personal growth.\n"
-    .string "That is our biggest objective.\n"
-    .string "\n"
-    .string "Press the A Button, and let your\n"
-    .string "adventure begin!$"
+    .string "Make sure to input the same rival\n"
+    .string "name as your friends!$"
 
 gOakSpeech_Text_WelcomeToTheWorld::
     .string "Hello, there!\n"
@@ -223,13 +205,16 @@ gOakSpeech_Text_WhatWasHisName::
     .string "This is my grandson.\p"
     .string "He's been your rival since you both\n"
     .string "were babies.\p"
-    .string "…Erm, what was his name now?$"
+    .string "…Erm, what was his name now?\n"
+    .string "(THIS RANDOMIZES THE GAME!)$"
 
 gOakSpeech_Text_YourRivalsNameWhatWasIt::
-    .string "Your rival's name, what was it now?$"
+    .string "Your rival's name, what was it now?\n$"
+    .string "(THIS RANDOMIZES THE GAME!)$"
 
 gOakSpeech_Text_ConfirmRivalName::
-    .string "…Er, was it {RIVAL}?$"
+    .string "…Er, was it {RIVAL}?\n"
+    .string "(THIS RANDOMIZES THE GAME!)$"
 
 gOakSpeech_Text_RememberRivalsName::
     .string "That's right! I remember now!\n"

--- a/include/battle_gfx_sfx_util.h
+++ b/include/battle_gfx_sfx_util.h
@@ -5,6 +5,7 @@ void AllocateBattleSpritesData(void);
 void FreeBattleSpritesData(void);
 void SpriteCB_WaitForBattlerBallReleaseAnim(struct Sprite *sprite);
 void SpriteCB_TrainerSlideIn(struct Sprite *sprite);
+void SpriteCB_TrainerSpawn(struct Sprite *sprite);
 void InitAndLaunchChosenStatusAnimation(bool8 isStatus2, u32 status);
 bool8 TryHandleLaunchBattleTableAnimation(u8 activeBattler, u8 atkBattler, u8 defBattler, u8 tableId, u16 argument);
 void InitAndLaunchSpecialAnimation(u8 activeBattler, u8 atkBattler, u8 defBattler, u8 tableId);

--- a/src/battle_controller_link_opponent.c
+++ b/src/battle_controller_link_opponent.c
@@ -1190,7 +1190,7 @@ static void LinkOpponentHandleDrawTrainerPic(void)
     gSprites[gBattlerSpriteIds[gActiveBattler]].data[5] = gSprites[gBattlerSpriteIds[gActiveBattler]].oam.tileNum;
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.tileNum = GetSpriteTileStartByTag(gTrainerFrontPicTable[trainerPicId].tag);
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.affineParam = trainerPicId;
-    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSlideIn;
+    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSpawn;
 
     gBattlerControllerFuncs[gActiveBattler] = CompleteOnBattlerSpriteCallbackDummy;
 }

--- a/src/battle_controller_link_partner.c
+++ b/src/battle_controller_link_partner.c
@@ -1113,7 +1113,7 @@ static void LinkPartnerHandleDrawTrainerPic(void)
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.paletteNum = gActiveBattler;
     gSprites[gBattlerSpriteIds[gActiveBattler]].x2 = DISPLAY_WIDTH;
     gSprites[gBattlerSpriteIds[gActiveBattler]].sSpeedX = -2;
-    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSlideIn;
+    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSpawn;
 
     gBattlerControllerFuncs[gActiveBattler] = CompleteOnBattlerSpriteCallbackDummy;
 }

--- a/src/battle_controller_opponent.c
+++ b/src/battle_controller_opponent.c
@@ -1144,7 +1144,7 @@ static void OpponentHandleDrawTrainerPic(void)
     gSprites[gBattlerSpriteIds[gActiveBattler]].data[5] = gSprites[gBattlerSpriteIds[gActiveBattler]].oam.tileNum;
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.tileNum = GetSpriteTileStartByTag(gTrainerFrontPicTable[trainerPicId].tag);
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.affineParam = trainerPicId;
-    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSlideIn;
+    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSpawn;
     gBattlerControllerFuncs[gActiveBattler] = CompleteOnBattlerSpriteCallbackDummy;
 }
 
@@ -1175,7 +1175,7 @@ static void OpponentHandleTrainerSlide(void)
     gSprites[gBattlerSpriteIds[gActiveBattler]].data[5] = gSprites[gBattlerSpriteIds[gActiveBattler]].oam.tileNum;
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.tileNum = GetSpriteTileStartByTag(gTrainerFrontPicTable[trainerPicId].tag);
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.affineParam = trainerPicId;
-    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSlideIn;
+    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSpawn;
     gBattlerControllerFuncs[gActiveBattler] = CompleteOnBattlerSpriteCallbackDummy2;
 }
 

--- a/src/battle_controller_player.c
+++ b/src/battle_controller_player.c
@@ -2194,7 +2194,7 @@ static void PlayerHandleDrawTrainerPic(void)
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.paletteNum = gActiveBattler;
     gSprites[gBattlerSpriteIds[gActiveBattler]].x2 = DISPLAY_WIDTH;
     gSprites[gBattlerSpriteIds[gActiveBattler]].data[0] = -2;
-    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSlideIn;
+    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSpawn;
     gBattlerControllerFuncs[gActiveBattler] = CompleteOnBattlerSpriteCallbackDummy;
 }
 
@@ -2224,7 +2224,7 @@ static void PlayerHandleTrainerSlide(void)
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.paletteNum = gActiveBattler;
     gSprites[gBattlerSpriteIds[gActiveBattler]].x2 = -96;
     gSprites[gBattlerSpriteIds[gActiveBattler]].data[0] = 2;
-    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSlideIn;
+    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSpawn;
     gBattlerControllerFuncs[gActiveBattler] = CompleteOnBattlerSpriteCallbackDummy2;
 }
 

--- a/src/battle_controller_pokedude.c
+++ b/src/battle_controller_pokedude.c
@@ -1359,7 +1359,7 @@ static void PokedudeHandleDrawTrainerPic(void)
         gSprites[gBattlerSpriteIds[gActiveBattler]].x2 = DISPLAY_WIDTH;
         gSprites[gBattlerSpriteIds[gActiveBattler]].data[0] = -2;
         gSprites[gBattlerSpriteIds[gActiveBattler]].oam.paletteNum = gActiveBattler;
-        gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSlideIn;
+        gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSpawn;
     }
     else
     {
@@ -1376,7 +1376,7 @@ static void PokedudeHandleDrawTrainerPic(void)
         gSprites[gBattlerSpriteIds[gActiveBattler]].data[5] = gSprites[gBattlerSpriteIds[gActiveBattler]].oam.tileNum;
         gSprites[gBattlerSpriteIds[gActiveBattler]].oam.tileNum = GetSpriteTileStartByTag(gTrainerFrontPicTable[tranerPicid].tag);
         gSprites[gBattlerSpriteIds[gActiveBattler]].oam.affineParam = tranerPicid;
-        gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSlideIn;
+        gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSpawn;
     }
     gBattlerControllerFuncs[gActiveBattler] = CompleteOnBattlerSpriteCallbackDummy;
 }
@@ -1392,7 +1392,7 @@ static void PokedudeHandleTrainerSlide(void)
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.paletteNum = gActiveBattler;
     gSprites[gBattlerSpriteIds[gActiveBattler]].x2 = -96;
     gSprites[gBattlerSpriteIds[gActiveBattler]].data[0] = 2;
-    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSlideIn;
+    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSpawn;
     gBattlerControllerFuncs[gActiveBattler] = CompleteOnBattlerSpriteCallbackDummy2;
 }
 

--- a/src/battle_controller_safari.c
+++ b/src/battle_controller_safari.c
@@ -348,7 +348,7 @@ static void SafariHandleDrawTrainerPic(void)
     gSprites[gBattlerSpriteIds[gActiveBattler]].oam.paletteNum = gActiveBattler;
     gSprites[gBattlerSpriteIds[gActiveBattler]].x2 = DISPLAY_WIDTH;
     gSprites[gBattlerSpriteIds[gActiveBattler]].data[0] = -2;
-    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSlideIn;
+    gSprites[gBattlerSpriteIds[gActiveBattler]].callback = SpriteCB_TrainerSpawn;
     gBattlerControllerFuncs[gActiveBattler] = CompleteOnBattlerSpriteCallbackDummy;
 }
 

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -158,6 +158,27 @@ static void DoBattleSpriteAffineAnim(struct Sprite *sprite, bool8 arg1)
     AnimateSprite(sprite);
 }
 
+// Slide up to 0 if necessary (used by multi battle intro)
+// From https://github.com/pret/pokeemerald/commit/9c144896d404751d0d5e41ffbb1fa2153d1e14af#diff-1e33c3dd8be8f19905a1f76a329e2347042673054e6201d12971bf06fab862a0R404
+static void SpriteCB_TrainerSlideVertical(struct Sprite *sprite)
+{
+    sprite->y2 -= 2;
+    if (sprite->y2 == 0)
+        sprite->callback = SpriteCallbackDummy;
+}
+
+void SpriteCB_TrainerSpawn(struct Sprite *sprite)
+{
+    if (!(gIntroSlideFlags & 1))
+    {
+        sprite->x2 = 0;
+        if (sprite->y2 != 0)
+            sprite->callback = SpriteCB_TrainerSlideVertical;
+        else
+            sprite->callback = SpriteCallbackDummy;
+    }
+}
+
 void SpriteCB_TrainerSlideIn(struct Sprite *sprite)
 {
     if (!(gIntroSlideFlags & 1))

--- a/src/battle_interface.c
+++ b/src/battle_interface.c
@@ -1861,7 +1861,7 @@ s32 MoveBattleBar(u8 battlerId, u8 healthboxSpriteId, u8 whichBar, u8 unused)
                                           gBattleSpritesDataPtr->battleBars[battlerId].receivedValue,
                                           &gBattleSpritesDataPtr->battleBars[battlerId].currValue,
                                           B_HEALTHBAR_NUM_TILES,
-                                          1);
+                                          1 * 4);
     }
     else // exp bar
     {
@@ -1879,7 +1879,7 @@ s32 MoveBattleBar(u8 battlerId, u8 healthboxSpriteId, u8 whichBar, u8 unused)
                                           gBattleSpritesDataPtr->battleBars[battlerId].receivedValue,
                                           &gBattleSpritesDataPtr->battleBars[battlerId].currValue,
                                           B_EXPBAR_NUM_TILES,
-                                          increment);
+                                          increment * 4);
     }
 
     if (whichBar == EXP_BAR || (whichBar == HEALTH_BAR && !gBattleSpritesDataPtr->battlerData[battlerId].hpNumbersNoBars))

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -665,18 +665,6 @@ static void CB2_InitBattleInternal(void)
     gBattle_WIN0V = WIN_RANGE(DISPLAY_HEIGHT / 2, DISPLAY_HEIGHT / 2 + 1);
     ScanlineEffect_Clear();
 
-    for (i = 0; i < 80; ++i)
-    {
-        gScanlineEffectRegBuffers[0][i] = 0xF0;
-        gScanlineEffectRegBuffers[1][i] = 0xF0;
-    }
-    for (; i < 160; ++i)
-    {
-        gScanlineEffectRegBuffers[0][i] = 0xFF10;
-        gScanlineEffectRegBuffers[1][i] = 0xFF10;
-    }
-    ScanlineEffect_SetParams(sIntroScanlineParams16Bit);
-
     ResetPaletteFade();
     gBattle_BG0_X = 0;
     gBattle_BG0_Y = 0;
@@ -693,7 +681,6 @@ static void CB2_InitBattleInternal(void)
     LoadBattleTextboxAndBackground();
     ResetSpriteData();
     ResetTasks();
-    DrawBattleEntryBackground();
     FreeAllSpritePalettes();
     gReservedSpritePaletteCount = 4;
     SetVBlankCallback(VBlankCB_Battle);
@@ -1555,7 +1542,7 @@ static u8 CreateNPCTrainerParty(struct Pokemon *party, u16 trainerNum)
         {
             // This is probably overcomplicated.
             // 49 is used to avoid "rare" route-specific pokemon.
-            manual_random = ((trainerNum * (i+1) + 1) % 49) + 1;
+            manual_random = ((trainerNum * (i+1)) % 49) + 1;
 
             if (gTrainers[trainerNum].doubleBattle == TRUE)
                 personalityValue = 0x80;
@@ -1894,20 +1881,6 @@ void SpriteCB_EnemyMon(struct Sprite *sprite)
 {
     sprite->callback = SpriteCB_MoveWildMonToRight;
     StartSpriteAnimIfDifferent(sprite, 0);
-    BeginNormalPaletteFade(0x20000, 0, 10, 10, RGB(8, 8, 8));
-}
-
-static void SpriteCB_MoveWildMonToRight(struct Sprite *sprite)
-{
-    if ((gIntroSlideFlags & 1) == 0)
-    {
-        sprite->x2 += 2;
-        if (sprite->x2 == 0)
-        {
-            sprite->callback = SpriteCB_WildMonShowHealthbox;
-            PlayCry_Normal(sprite->data[2], 25);
-        }
-    }
 }
 
 static void SpriteCB_WildMonShowHealthbox(struct Sprite *sprite)
@@ -1918,7 +1891,16 @@ static void SpriteCB_WildMonShowHealthbox(struct Sprite *sprite)
         SetHealthboxSpriteVisible(gHealthboxSpriteIds[sprite->sBattler]);
         sprite->callback = SpriteCallbackDummy_2;
         StartSpriteAnimIfDifferent(sprite, 0);
-        BeginNormalPaletteFade(0x20000, 0, 10, 0, RGB(8, 8, 8));
+    }
+}
+
+static void SpriteCB_MoveWildMonToRight(struct Sprite *sprite)
+{
+    if ((gIntroSlideFlags & 1) == 0)
+    {
+        sprite->x2 = 0;
+        sprite->callback = SpriteCB_WildMonShowHealthbox;
+        PlayCry_Normal(sprite->data[2], 25);
     }
 }
 

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -895,8 +895,6 @@ void ClearTrainerFlag(u16 trainerId)
 void StartTrainerBattle(void)
 {
     gBattleTypeFlags = BATTLE_TYPE_TRAINER;
-    if (GetTrainerBattleMode() == TRAINER_BATTLE_EARLY_RIVAL && GetRivalBattleFlags() & RIVAL_BATTLE_TUTORIAL)
-        gBattleTypeFlags |= BATTLE_TYPE_FIRST_BATTLE;
     gMain.savedCallback = CB2_EndTrainerBattle;
     DoTrainerBattle();
     ScriptContext_Stop();

--- a/src/bike.c
+++ b/src/bike.c
@@ -242,33 +242,17 @@ static u8 GetBikeCollisionAt(struct ObjectEvent *playerObjEvent, s16 x, s16 y, u
 
 bool8 RS_IsRunningDisallowed(u8 r0)
 {
-    if (MetatileBehaviorForbidsBiking(r0))
-        return TRUE;
-    if (gMapHeader.mapType != MAP_TYPE_INDOOR)
-        return FALSE;
-    else
-        return TRUE;
+    return FALSE;
 }
 
 bool32 IsRunningDisallowed(u8 metatileBehavior)
 {
-    if (!gMapHeader.allowRunning)
-        return TRUE;
-    if (MetatileBehaviorForbidsBiking(metatileBehavior) != TRUE)
-        return FALSE;
-    else
-        return TRUE;
+    return FALSE;
 }
 
 static bool8 MetatileBehaviorForbidsBiking(u8 metatileBehavior)
 {
-    if (MetatileBehavior_IsRunningDisallowed(metatileBehavior))
-        return TRUE;
-    if (!MetatileBehavior_IsFortreeBridge(metatileBehavior))
-        return FALSE;
-    if (PlayerGetElevation() & 1)
-        return FALSE;
-    return TRUE;
+    return FALSE;
 }
 
 static bool8 CanBikeFaceDirectionOnRail(u8 direction, u8 metatileBehavior)

--- a/src/event_data.c
+++ b/src/event_data.c
@@ -90,28 +90,17 @@ static bool32 IsNationalPokedexEnabled_RSE(void)
 
 void DisableNationalPokedex(void)
 {
-    u16 *nationalDexVar = GetVarPointer(VAR_NATIONAL_DEX);
-    gSaveBlock2Ptr->pokedex.nationalMagic = 0;
-    *nationalDexVar = 0;
-    FlagClear(FLAG_SYS_NATIONAL_DEX);
+  // No-op because it can't be disabled in this mod.
 }
 
 void EnableNationalPokedex(void)
 {
-    u16 *nationalDexVar = GetVarPointer(VAR_NATIONAL_DEX);
-    gSaveBlock2Ptr->pokedex.nationalMagic = 0xB9;
-    *nationalDexVar = 0x6258;
-    FlagSet(FLAG_SYS_NATIONAL_DEX);
+  // No-op because it's always enabled in this mod.
 }
 
 bool32 IsNationalPokedexEnabled(void)
 {
-    if (gSaveBlock2Ptr->pokedex.nationalMagic == 0xB9
-            && VarGet(VAR_NATIONAL_DEX) == 0x6258
-            && FlagGet(FLAG_SYS_NATIONAL_DEX))
-        return TRUE;
-
-    return FALSE;
+  return TRUE;
 }
 
 void DisableMysteryGift(void)

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -185,11 +185,12 @@ static void npc_clear_strange_bits(struct ObjectEvent *objEvent)
 
 static void MovePlayerAvatarUsingKeypadInput(u8 direction, u16 newKeys, u16 heldKeys)
 {
-    if ((gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_MACH_BIKE)
-        || (gPlayerAvatar.flags & PLAYER_AVATAR_FLAG_ACRO_BIKE))
-        MovePlayerOnBike(direction, newKeys, heldKeys);
-    else
+
+    if (heldKeys & B_BUTTON) {
         MovePlayerNotOnBike(direction, heldKeys);
+    } else {
+        MovePlayerOnBike(direction, newKeys, heldKeys);
+    }
 }
 
 static void PlayerAllowForcedMovementIfMovingSameDirection(void)
@@ -513,23 +514,10 @@ static void PlayerNotOnBikeMoving(u8 direction, u16 heldKeys)
         return;
     }
 
-    if ((heldKeys & B_BUTTON) && FlagGet(FLAG_SYS_B_DASH)
-        && !IsRunningDisallowed(gObjectEvents[gPlayerAvatar.objectEventId].currentMetatileBehavior))
-    {
-        if (PlayerIsMovingOnRockStairs(direction))
-            PlayerRunSlow(direction);
-        else
-            PlayerRun(direction);
-        gPlayerAvatar.flags |= PLAYER_AVATAR_FLAG_DASH;
-        return;
-    }
+    if (PlayerIsMovingOnRockStairs(direction))
+        PlayerWalkSlow(direction);
     else
-    {
-        if (PlayerIsMovingOnRockStairs(direction))
-            PlayerWalkSlow(direction);
-        else
-            PlayerWalkNormal(direction);
-    }
+        PlayerWalkNormal(direction);
 }
 
 bool32 PlayerIsMovingOnRockStairs(u8 direction)

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -60,7 +60,7 @@ static void InitPlayerTrainerId(void)
 
 static void SetDefaultOptions(void)
 {
-    gSaveBlock2Ptr->optionsTextSpeed = OPTIONS_TEXT_SPEED_MID;
+    gSaveBlock2Ptr->optionsTextSpeed = OPTIONS_TEXT_SPEED_FAST;
     gSaveBlock2Ptr->optionsWindowFrameType = 0;
     gSaveBlock2Ptr->optionsSound = OPTIONS_SOUND_MONO;
     gSaveBlock2Ptr->optionsBattleStyle = OPTIONS_BATTLE_STYLE_SHIFT;
@@ -155,6 +155,7 @@ void NewGameInitData(void)
     VarSet(VAR_GRASS_STARTER, GetSpeciesFromGroup(SPECIES_BULBASAUR, 0));
     VarSet(VAR_FIRE_STARTER, GetSpeciesFromGroup(SPECIES_CHARMANDER, 0));
     VarSet(VAR_WATER_STARTER, GetSpeciesFromGroup(SPECIES_SQUIRTLE, 0));
+
 }
 
 static void ResetMiniGamesResults(void)

--- a/src/new_menu_helpers.c
+++ b/src/new_menu_helpers.c
@@ -659,7 +659,7 @@ u8 GetTextSpeedSetting(void)
 {
     u32 speed;
     if (gSaveBlock2Ptr->optionsTextSpeed > OPTIONS_TEXT_SPEED_FAST)
-        gSaveBlock2Ptr->optionsTextSpeed = OPTIONS_TEXT_SPEED_MID;
+        gSaveBlock2Ptr->optionsTextSpeed = OPTIONS_TEXT_SPEED_FAST;
     return sTextSpeedFrameDelays[gSaveBlock2Ptr->optionsTextSpeed];
 }
 

--- a/src/oak_speech.c
+++ b/src/oak_speech.c
@@ -334,16 +334,12 @@ static const u8 sTextColor_DarkGray[] = { 0, 2, 3, 0 };
 enum
 {
     PIKACHU_INTRO_PAGE_1,
-    PIKACHU_INTRO_PAGE_2,
-    PIKACHU_INTRO_PAGE_3,
     NUM_PIKACHU_INTRO_PAGES,
 };
 
 static const u8 *const sPikachuIntro_Strings[NUM_PIKACHU_INTRO_PAGES] =
 {
     [PIKACHU_INTRO_PAGE_1] = gPikachuIntro_Text_Page1,
-    [PIKACHU_INTRO_PAGE_2] = gPikachuIntro_Text_Page2,
-    [PIKACHU_INTRO_PAGE_3] = gPikachuIntro_Text_Page3
 };
 
 #define GFX_TAG_PLATFORM     0x1000
@@ -774,7 +770,6 @@ static void Task_NewGameScene(u8 taskId)
         FillBgTilemapBufferRect_Palette0(1, 0xD00F, 0,  0, 30, 2);
         FillBgTilemapBufferRect_Palette0(1, 0xD002, 0,  2, 30, 1);
         FillBgTilemapBufferRect_Palette0(1, 0xD00E, 0, 19, 30, 1);
-        ControlsGuide_LoadPage1();
         gPaletteFade.bufferTransferDisabled = FALSE;
         gTasks[taskId].tTextCursorSpriteId = CreateTextCursorSprite(0, 230, 149, 0, 0);
         BlendPalettes(PALETTES_ALL, 16, RGB_BLACK);
@@ -786,7 +781,7 @@ static void Task_NewGameScene(u8 taskId)
         ShowBg(1);
         SetVBlankCallback(VBlankCB_NewGameScene);
         PlayBGM(MUS_NEW_GAME_INSTRUCT);
-        gTasks[taskId].func = Task_ControlsGuide_HandleInput;
+        gTasks[taskId].func = Task_PikachuIntro_LoadPage1;
         gMain.state = 0;
         return;
     }

--- a/src/pokemon_groups.c
+++ b/src/pokemon_groups.c
@@ -123,7 +123,6 @@ const u16 gGroup_BugStage1[] =
   SPECIES_LEDYBA,
   SPECIES_SPINARAK,
   SPECIES_WURMPLE,
-  //SPECIES_WURMPLE,
   SPECIES_YANMA,
 };
 
@@ -1474,12 +1473,11 @@ u16 GetSpeciesFromGroup(u16 species, u16 manual_random) {
     //
     // Don't take route into account, so that rival
     // has the same starter throughout the game.
-    gSpeciesNames[(species + 2) / 3];
-
-    // combinedHash = HashCombine(GameHash(), (species + 2) / 3 * 31);
     combinedHash = HashCombine(GameHash(), Hash(gSpeciesNames[(species + 2) / 3]));
     return IndexInto(group, combinedHash);
   }
+
+  random = (manual_random ? manual_random : Random()) % 50;
 
   if (random == 0) {
     // 2% chance that the player found the "rare" species
@@ -1490,11 +1488,11 @@ u16 GetSpeciesFromGroup(u16 species, u16 manual_random) {
   } else if (random <= 17) {
     // 34% chance the player found the less-common mapping
     // to `species`.
-    combinedHash = HashCombine(GameHash(), MapHash() + species);
+    combinedHash = HashCombine(GameHash(), MapHash() + (31 * species));
   } else {
     // 64% chance the player found the more-common mapping
     // to `species`.
-    combinedHash = HashCombine(MapHash() , GameHash() - species);
+    combinedHash = HashCombine(MapHash(), GameHash() - (31 * species));
   }
 
   return IndexInto(group, combinedHash);

--- a/src/quest_log.c
+++ b/src/quest_log.c
@@ -447,27 +447,8 @@ static bool8 TryRecordActionSequence(struct QuestLogAction * actions)
 
 void TryStartQuestLogPlayback(u8 taskId)
 {
-    u8 i;
-
-    QL_EnableRecordingSteps();
-    sNumScenes = 0;
-    for (i = 0; i < QUEST_LOG_SCENE_COUNT; i++)
-    {
-        if (gSaveBlock1Ptr->questLog[i].startType != 0)
-            sNumScenes++;
-    }
-
-    if (sNumScenes != 0)
-    {
-        gHelpSystemEnabled = FALSE;
-        Task_BeginQuestLogPlayback(taskId);
-        DestroyTask(taskId);
-    }
-    else
-    {
-        SetMainCallback2(CB2_ContinueSavedGame);
-        DestroyTask(taskId);
-    }
+    SetMainCallback2(CB2_ContinueSavedGame);
+    DestroyTask(taskId);
 }
 
 static void Task_BeginQuestLogPlayback(u8 taskId)

--- a/src/text.c
+++ b/src/text.c
@@ -637,19 +637,7 @@ u16 RenderText(struct TextPrinter *textPrinter)
     switch (textPrinter->state)
     {
     case RENDER_STATE_HANDLE_CHAR:
-        if (JOY_HELD(A_BUTTON | B_BUTTON) && subStruct->hasPrintBeenSpedUp)
-            textPrinter->delayCounter = 0;
-
-        if (textPrinter->delayCounter && textPrinter->textSpeed)
-        {
-            textPrinter->delayCounter--;
-            if (gTextFlags.canABSpeedUpPrint && JOY_NEW(A_BUTTON | B_BUTTON))
-            {
-                subStruct->hasPrintBeenSpedUp = TRUE;
-                textPrinter->delayCounter = 0;
-            }
-            return RENDER_UPDATE;
-        }
+        textPrinter->delayCounter = 0;
 
         if (gTextFlags.autoScroll)
             textPrinter->delayCounter = 1;


### PR DESCRIPTION
Bugfixes
- Actually use a random number to map Pokemon to groups. This line was accidentally deleted before pushing last time.
- Enable the national dex by default. This unblocks evolutions to non-Kanto Pokemon.

Speedups
- Make walking speed equal to biking speed. Pushing B temporarily reverts to regular walking speed.
- Speed up battle intros: https://www.pokecommunity.com/threads/simple-modifications-directory.416647/page-18#post-10473117
- Make health and XP bars more 4x faster.
- Make text default to fast and automatically act as if you're holding A.
- Remove Oak's tips from the first rival battle.
- Remove the controls tutorial, shorten the Pikachu intro (and make it reference the challenge), and emphasize that your rival's name will impact the pokemon/items you'll encounter.
- Set the pause/wait time to the lowest possible value.